### PR TITLE
Updated material to run singularity w/o root privileges

### DIFF
--- a/_episodes/02-running-containers.md
+++ b/_episodes/02-running-containers.md
@@ -27,9 +27,43 @@ singularity --help
 
 # Downloading Images
 
-The [Singularity Container Library](https://cloud.sylabs.io/library) is the official image registry.
-Images built by users are accessible using the CLI, and images become containers at runtime.
+Apptainer/Singularity can store, search and retrieve images in registries.
+Images built by other users can be accessible using the CLI, can be pulled down, and become containers at runtime.
 
+Sylabs, the developers of one Singularity flavor, hosts a public image registry, the
+[Singularity Container Library](https://cloud.sylabs.io/library) where many user built images are available.
+
+The Linux Foundation flavor, Apptainer, does not point by default to the Sylab registry as previous versions did.
+You can change that running these commands (documented [here](https://apptainer.org/docs/user/main/endpoint.html#restoring-pre-apptainer-library-behavior)):
+```bash
+apptainer remote add --no-login SylabsCloud cloud.sycloud.io
+```
+~~~
+INFO:    Remote "SylabsCloud" added.
+~~~
+{: .output}
+```bash
+apptainer remote use SylabsCloud
+```
+~~~
+INFO:    Remote "SylabsCloud" now in use.
+~~~
+{: .output}
+```bash
+apptainer remote list
+```
+~~~
+Cloud Services Endpoints
+========================
+
+NAME           URI                  ACTIVE  GLOBAL  EXCLUSIVE
+DefaultRemote  cloud.apptainer.org  NO      YES     NO
+SylabsCloud    cloud.sycloud.io     YES     NO      NO
+...
+~~~
+{: .output}
+
+Once you have setup a working registry you can use search and pull.
 The command `search` provides containers of interest
 and information about groups and collections. For example:
 
@@ -58,9 +92,9 @@ and the image is stored locally as a `.sif` file (`centos7-devel_latest.sif`, in
 
 > ## Docker Images
 >
-> Fortunately, Singularity is also compatible with Docker images. [Docker Hub](https://hub.docker.com/)
-> is one of the largest libraries available, and any image hosted on the hub can be easily downloaded
-> with the `docker://` URL as reference:
+> Fortunately, Singularity is also compatible with Docker images. There are many more registries with Docker images.
+> [Docker Hub](https://hub.docker.com/) is one of the largest libraries available,
+> and any image hosted on the hub can be easily downloaded with the `docker://` URL as reference:
 > ```bash
 > singularity pull docker://centos:centos7
 > ```
@@ -95,6 +129,8 @@ uid=1001(myuser) gid=1001(myuser) groups=1001(myuser),500(myothergroup)
 ~~~
 {: .output}
 
+When an outside directory is accessible also inside Singularity we say it is bound, or bind mounted. The path to access it
+may differ but anything you do to its content outside is visible inside and vice-versa.
 By default, Singularity bind the home of the user, `/tmp` and `$PWD` into the container. It means your files
 at `hostname:~/` are accessible inside the container. You can specify additional bind mounts using the `--bind` option.
 For example, let's say `/cvmfs` is available in the host, and you would like to have access to CVMFS inside the
@@ -181,7 +217,8 @@ with Singularity available.
 
 ## Exiting a singularity image
 
-The `exit` command exits a singularity instance. Note that when exiting from the singularity image all the running processes are killed (stopped).
+The `exit` command (Control+d) exits a singularity instance. Note that when exiting from the singularity image all the running processes are killed (stopped).
+Changes saved into bound directories are preserved. By default anything else in the container is lost (we'll see later about writable images).
 
 ```bash
 Singularity> exit

--- a/_episodes/04-building-containers.md
+++ b/_episodes/04-building-containers.md
@@ -147,4 +147,3 @@ We will automate this in the next section.
 > > Notice how we did not need `--fakeroot` for the installation since pip installs user packages.
 > {: .solution}
 {: .challenge}
-

--- a/_episodes/04-building-containers.md
+++ b/_episodes/04-building-containers.md
@@ -16,10 +16,9 @@ Running containers from the available public images is not the only option. In m
 an image or even to create a new one from scratch. For such purposes, Singularity provides the command `build`,
 defined in the documentation as the _Swiss army knife_ of container creation.
 
-Sometimes, building images requires access to a machine with Singularity and superuser permissions
-(if you need to manipulate the packager manager, for example). In such case the usual workflow is to prepare
-a container in a build environment (like your laptop), either with an interactive session or from a definition file,
-and then deploy the container into a production environment for execution (as your institutional cluster).
+The usual workflow is to prepare and test a container in a build environment (like your laptop),
+either with an interactive session or from a definition file,
+and then to deploy the container into a production environment for execution (as your institutional cluster).
 
 <figure>
   <img src="https://journals.plos.org/plosone/article/figure/image?size=large&id=10.1371/journal.pone.0177459.g001" alt="Singularity usage workflow"/>
@@ -28,99 +27,74 @@ and then deploy the container into a production environment for execution (as yo
 
 ## Build a container in an interactive session
 
-Images contained in the `.sif` files are immutable objects, ideal for reproducibility. However, it is convenient to
-build images interactively.
+While images contained in the `.sif` files are more compact and immutable objects, ideal for reproducibility, for building and testing images is
+more convenient the use of a _sandbox_, which can be easily modified.
 
 The command `build` provides a flag `--sandbox` that will create a writable directory:
 ```bash
-singularity build --sandbox myPython docker://python:3.9
-```
-The container name is `myPython`, and it has been initialized from the [Docker image](https://hub.docker.com/_/python)
-of Python using the tag 3.9.
-
-To initialize an interactive session use `shell`.
-Add the --writable flag to modify files within the container.
-```bash
-singularity shell --writable myPython
-```
-Once inside the container, you can make changes as needed for your work. For example, making
-[Uproot](https://uproot.readthedocs.io/en/latest/index.html) available
-```bash
-Singularity> pip install uproot awkward
-```
-Exit the container. Then confirm that uproot is available even after closing the shell:
-```bash
-singularity exec myPython python -c "import uproot; print(uproot.__doc__)"
-```
-~~~
-Uproot: ROOT I/O in pure Python and NumPy.
-...
-~~~
-{: .output}
-
-## Building a container with superuser permissions
-
-Some operations, like the installation of new components, will require superuser access. To be superuser inside the container,
-you must be a superuser outside (in the host machine). You can either open a shell as root, or use `sudo`:
-
-```bash
-sudo singularity shell --writable myCentOS7
+singularity build --sandbox myCentOS7 docker://centos:centos7
 ```
 The container name is `myCentOS7`, and it has been initialized from the [official Docker image](https://hub.docker.com/_/centos)
-of CentOS7. You can verify that opening a shell with `sudo` makes you root inside the container
+of CentOS7.
+To initialize an interactive session use the `shell` command. And to write files within the sandbox directory use the `--writable` option.
+Finally, the installation of new components will require superuser access inside the container, so use also the `--fakeroot` option, unless you are already root also outside.
 ```bash
+singularity shell --writable --fakeroot myCentOS7
 Singularity> whoami
 ```
 ~~~
 root
 ~~~
 {: .output}
+> ## `--fakeroot` is not root
+> ATTENTION! [`--fakeroot`](https://apptainer.org/docs/user/main/fakeroot.html) allows you to be root inside a container that you own but is not changing who you are outside.
+> All the outside actions and the writing on bound files and directories will happen as your outside user, even if in the container is done by root.
+{: .callout}
 
-As a second example, let's create a container with Pythia8 available using the `myCentOS7` sandbox.
+As an example, let's create a container with Pythia8 available using the `myCentOS7` sandbox.
 First, we need to install the development tools (remember that in this interactive session we are superuser):
 ```bash
 Singularity> yum groupinstall 'Development Tools'
 Singularity> yum install python3-devel
 ```
-where `yum` is the [package manager used in RHEL distributions](https://en.wikipedia.org/wiki/Yum_(software))
+Where `yum` is the [package manager used in RHEL distributions](https://en.wikipedia.org/wiki/Yum_(software))
 (like CentOS).
 
 We will follow the
-installation steps described in the [Pythia website](http://home.thep.lu.se/~torbjorn/Pythia.html).
-In short, we just need to execute:
+installation steps described in the [Pythia website](https://pythia.org/).
+Here is a summary of the commands you will need (you may need to adjust link and commands if there is a new Pythia version):
 
-~~~bash
+```bash
 Singularity> mkdir /opt/pythia && cd /opt/pythia
-Singularity> curl -o pythia8303.tgz http://home.thep.lu.se/~torbjorn/pythia8/pythia8303.tgz
-Singularity> tar xvfz pythia8303.tgz
-~~~
-{: .source}
+Singularity> curl -o pythia8307.tgz https://pythia.org/download/pythia83/pythia8307.tgz
+Singularity> tar xvfz pythia8307.tgz
+Singularity> ln -s pythia8307 pythia8
+```
 
 To enable the Python interface, we add the flag `--with-python-include` during the configuration, pointing to the
 location of the Python headers:
 
-~~~bash
+```bash
+Singularity> cd pythia8307
 Singularity> ./configure --with-python-include=/usr/include/python3.6m/
 Singularity> make
 
 Singularity> exit
-~~~
-{: .source}
+```
 
-Now, open an interactive session with your user (no `sudo`). You can use now the container with Pythia8 ready in a
+Now, open an interactive session with your user (no `--fakeroot`). You can use now the container with Pythia8 ready in a
 few steps. Let's use the Python interface:
 
-~~~bash
+```bash
 singularity shell myCentOS7
 
-Singularity> export PYTHONPATH=/opt/pythia/pythia8303/lib:$PYTHONPATH
-Singularity> export LD_LIBRARY_PATH=/opt/pythia/pythia8303/lib:$LD_LIBRARY_PATH
+Singularity> export PYTHONPATH=/opt/pythia/pythia8/lib:$PYTHONPATH
+Singularity> export LD_LIBRARY_PATH=/opt/pythia/pythia8/lib:$LD_LIBRARY_PATH
 Singularity> python3
 
 >>> import pythia8
 >>> pythia = pythia8.Pythia()
-~~~
-{: .source}
+```
 ~~~
  *------------------------------------------------------------------------------------*
  |                                                                                    |
@@ -128,13 +102,13 @@ Singularity> python3
  |  |                                                                              |  |
  |  |                                                                              |  |
  |  |   PPP   Y   Y  TTTTT  H   H  III    A      Welcome to the Lund Monte Carlo!  |  |
- |  |   P  P   Y Y     T    H   H   I    A A     This is PYTHIA version 8.303      |  |
- |  |   PPP     Y      T    HHHHH   I   AAAAA    Last date of change:  1 Sep 2020  |  |
+ |  |   P  P   Y Y     T    H   H   I    A A     This is PYTHIA version 8.307      |  |
+ |  |   PPP     Y      T    HHHHH   I   AAAAA    Last date of change: 25 Feb 2022  |  |
  |  |   P       Y      T    H   H   I   A   A                                      |  |
- |  |   P       Y      T    H   H  III  A   A    Now is 18 Dec 2020 at 18:50:33    |  |
+ |  |   P       Y      T    H   H  III  A   A    Now is 03 Nov 2022 at 18:38:40    |  |
 
 ...
- |  |   Copyright (C) 2020 Torbjorn Sjostrand                                      |  |
+ |  |   Copyright (C) 2022 Torbjorn Sjostrand                                      |  |
  |  |                                                                              |  |
  |  *------------------------------------------------------------------------------*  |
  |                                                                                    |
@@ -144,3 +118,33 @@ Singularity> python3
 
 Notice that we need to define the environment variables `PYTHONPATH` and `LD_LIBRARY_PATH` in order to use Pythia on Python.
 We will automate this in the next section.
+
+> ## Execute Python with PyROOT available
+>
+> Build a container to use uproot in Python 3.9.
+>
+> > ## Solution
+> >
+> > Start from the [Python 3.9 Docker image](https://hub.docker.com/_/python) and create the `myPython` sandbox:
+> > ```bash
+> > singularity build --sandbox myPython docker://python:3.9
+> > singularity shell --writable myPython
+> > ```
+> > Once inside the container, you can install [Uproot](https://uproot.readthedocs.io/en/latest/index.html).
+> > ```bash
+> > Singularity> python3 -m pip install --upgrade pip
+> > Singularity> python3 -m pip install uproot awkward
+> > ```
+> > Exit the container and use it as you like:
+> > ```bash
+> > singularity exec myPython python -c "import uproot; print(uproot.__doc__)"
+> > ```
+> > ~~~
+> > Uproot: ROOT I/O in pure Python and NumPy.
+> > ...
+> > ~~~
+> > {: .output}
+> > Notice how we did not need `--fakeroot` for the installation since pip installs user packages.
+> {: .solution}
+{: .challenge}
+

--- a/_episodes/05-definition-files.md
+++ b/_episodes/05-definition-files.md
@@ -36,7 +36,11 @@ The following recipe shows how to build a hello-world container, and run the con
   # Print Hello world when the image is loaded
   ```
 
-    In the above script, the first line - `BootStrap: docker` indicates that singularity will use docker to create the base OS to start the image. The `From: ubuntu:20.04` is given to singularity to start from a specific image/OS.  Any content within the  `%runscript` will be written to file that is executed when one runs the singularity image. The `echo "Hello World"` command will print the `Hello World` on the terminal. Finally the `#` hash is used to include comments within the definition file.
+    In the above script, the first line - `BootStrap: docker` indicates that singularity will use the docker protocol to retrieve the base OS to start the image.
+The `From: ubuntu:20.04` is given to singularity to start from a specific image/OS in Docker Hub.
+Any content within the  `%runscript` will be written to a file that is executed when one runs the singularity image.
+The `echo "Hello World"` command will print the `Hello World` on the terminal.
+Finally the `#` hash is used to include comments within the definition file.
 
 - Step 3: Build the image
 
@@ -53,12 +57,12 @@ The following recipe shows how to build a hello-world container, and run the con
   ```
 
 ### Deleting Singularity image
+To delete the helloworld Singularity image, simply delete the `helloworld.sif` file.
 
-To delete the helloworld Singularity image, use the following command:
-
-```bash
-singularity delete helloworld.sif
-```
+> Note that there is also a `singularity delete` command, but it is to delete an image from a remote library.
+> To learn more about using remote endpoints and pulling and pushing images from or to libraries, read
+> [Remote Endpoints](https://apptainer.org/docs/user/main/endpoint.html) and [Library API Registries](https://apptainer.org/docs/user/main/library_api.html).
+{: .callout}
 
 
 ## Example of a more elaborated definition file
@@ -98,7 +102,7 @@ From: ubuntu:20.04
 ~~~
 {: .source}
 
-Let's take a look at the definition file:
+Let's take a look at the [definition file](https://apptainer.org/docs/user/main/definition_files.html):
 * The first two lines define the base image. In this case, the image `ubuntu:20.04` from Docker Hub is used.
 * `%post` are lines to execute inside the container after the OS has been set. In this example, we are listing the
 steps that we would follow to install ROOT with a precompiled binary in an interactive session.
@@ -113,12 +117,12 @@ from the RooFit tutorial.
 Save this definition file as `myUbuntu.def`. To build the container, just provide the definition file as argument
 (executing as superuser):
 ```bash
-sudo singularity build rootInUbuntu.sif myUbuntu.def
+singularity build rootInUbuntu.sif myUbuntu.def
 ```
 
 
 Then, an interactive shell inside the container can be initialized with `singularity shell`, or
-execute a command with `singularity exec`. A third option is execute the actions defined inside `%runscript`
+a command executed with `singularity exec`. A third option is execute the actions defined inside `%runscript`
 simply by calling the container as an executable
 
 ```bash
@@ -142,18 +146,25 @@ Info in <TCanvas::Print>: png file rf101_basics.png has been created
 {: .output}
 
 You will find the output file `rf101_basics.png` in the location where the container was executed.
+If you don't have a DISPLAY setup, Root may complain. Ignore the error messages, the image will be created anyway,
+
+Here we have covered the basics with a few examples focused to HEP software.
+Check the [Apptainer docs](https://apptainer.org/docs/user/main/build_a_container.html) to see all the available
+options and more details related to the container creation.
+
 
 > ## Deploying your containers
-> Keep in mind that, while build a container requires superuser permissions, the execution can be performed anywhere.
+> Keep in mind that, while building a container may be time consuming, the execution can be immediate and anywhere your image is available.
 > Once your container is built with the requirements of your analysis, you can deploy it in a large cluster and execute it
 > as far as Singularity is available on the site.
+>
+> Libraries like [Sylabs Cloud Library](https://cloud.sylabs.io/library) ease the distribution of images.
+> Organizations like OSG provide instructions to [use available images](https://portal.osg-htc.org/documentation/htc_workloads/using_software/containers/)
+and [distribute custom images via CVMFS](https://portal.osg-htc.org/documentation/htc_workloads/using_software/containers-docker/).
 >
 > Be smart, and this will open endless possibilities in your workflow.
 {: .callout}
 
-Here we have covered the basics with a few examples focused to HEP software.
-Check the (Singularity docs)[https://sylabs.io/guides/3.6/user-guide/build_a_container.html] to see all the available
-options and more details related to the container creation.
 
 > ## Write a definition file to build a container with Pythia8 available in Python
 >
@@ -161,7 +172,7 @@ options and more details related to the container creation.
 > write a definition file to deploy a container with Pythia8 available.
 >
 > Take a look at
-> [`/opt/pythia/pythia8303/examples/main01.py`](https://gitlab.com/Pythia8/releases/-/blob/pythia8303/examples/main01.py)
+> [`/opt/pythia/pythia8307/examples/main01.py`](https://gitlab.com/Pythia8/releases/-/blob/pythia8307/examples/main01.py)
 > and define the `%runscript` to execute it using `python3`.
 >
 > (Tip: notice that main01.py requires `Makefile.inc`).
@@ -175,19 +186,19 @@ options and more details related to the container creation.
 > >     yum -y groupinstall 'Development Tools'
 > >     yum -y install python3-devel
 > >     mkdir /opt/pythia && cd /opt/pythia
-> >     curl -o pythia8303.tgz http://home.thep.lu.se/~torbjorn/pythia8/pythia8303.tgz
-> >     tar xvfz pythia8303.tgz
-> >     cd pythia8303
+> >     curl -o pythia8307.tgz https://pythia.org/download/pythia83/pythia8307.tgz
+> >     tar xvfz pythia8307.tgz
+> >     cd pythia8307
 > >     ./configure --with-python-include=/usr/include/python3.6m/
 > >     make
 > >
 > > %environment
-> >     export PYTHONPATH=/opt/pythia/pythia8303/lib:$PYTHONPATH
-> >     export LD_LIBRARY_PATH=/opt/pythia/pythia8303/lib:$LD_LIBRARY_PATH
+> >     export PYTHONPATH=/opt/pythia/pythia8307/lib:$PYTHONPATH
+> >     export LD_LIBRARY_PATH=/opt/pythia/pythia8307/lib:$LD_LIBRARY_PATH
 > >
 > > %runscript
-> >     cp /opt/pythia/pythia8303/Makefile.inc .
-> >     python3 /opt/pythia/pythia8303/examples/main01.py
+> >     cp /opt/pythia/pythia8307/Makefile.inc .
+> >     python3 /opt/pythia/pythia8307/examples/main01.py
 > >
 > > %labels
 > >     Author HEPTraining
@@ -197,10 +208,10 @@ options and more details related to the container creation.
 > > Build your container executing
 > >
 > > ```bash
-> > sudo singularity build pythiaInCentos7.sif myPythia8.def
+> > singularity build pythiaInCentos7.sif myPythia8.def
 > > ```
 > >
-> > And finally, execute the container to run [`main01.py`](https://gitlab.com/Pythia8/releases/-/blob/pythia8303/examples/main01.py)
+> > And finally, execute the container to run [`main01.py`](https://gitlab.com/Pythia8/releases/-/blob/pythia8307/examples/main01.py)
 > >
 >> > ```bash
 > > ./pythiaInCentos7.sif

--- a/_episodes/07-file-sharing.md
+++ b/_episodes/07-file-sharing.md
@@ -24,13 +24,13 @@ We have already used the option `--bind` earlier in the module when exploring th
 containers. In this chapter we will explore further options to bind directories from your host system to directories
 within your container.
 
-Remember that in Singularity, your user outside is the same inside the container. And the same happens with permissions and
-ownership for files in bind directories.
+Remember that in Singularity, your user outside is the same inside the container (except when using fakeroot).
+And the same happens with permissions and ownership for files in bind directories.
 
 ## Bind paths included by default
 
-For each container executed, Singularity binds automatically some directories by default, and other defined the system
-admin in the Singularity configuration. By default, Singularity binds:
+For each container executed, Singularity binds automatically some directories by default, and other defined
+by the system admin in the Singularity configuration. By default, Singularity binds:
 * The user's home directory ($HOME)
 * The current directory when the container is executed ($PWD)
 * System-defined paths: `/tmp`, `/proc`, `/dev`, etc.
@@ -40,7 +40,7 @@ Since this is defined in the configuration, it may vary from site to site.
 > ## Disabling system binds
 >
 > If for any reason you want to execute a container removing the default binds, the command-line option `--no-mount`
-> is available. For example, to disable bind of `/tmp`
+> is available. For example, to disable the bind of `/tmp`
 > ```bash
 > run --no-mount tmp my_container.sif
 > ```
@@ -49,7 +49,9 @@ Since this is defined in the configuration, it may vary from site to site.
 ## User-defined bind paths
 
 Singularity provides mechanisms to specify additional binds when executing a container via command-line
-or environment variables.
+or environment variables. Singularity offers a complex set of mechanism for binds or other mounts.
+Here we present the main points, refer to the
+[Bind Paths and Mounts documentation](https://apptainer.org/docs/user/main/bind_paths_and_mounts.html) for more.
 
 ### Bind with command-line options
 
@@ -63,8 +65,8 @@ paths will be rejected). For example
 singularity shell --bind /home/user/mydata:/data my_container.sif
 ```
 will bind the directory `mydata/` from the host as `/data` inside the container. If multiple directories must be
-available in the container, they can be defined with a comma between each pair of directories, i.e. using the
-syntax `source1:destination1,source2:destination2`.
+available in the container, you can repeat the option or they can be defined with a comma between each pair of directories,
+i.e. using the syntax `source1:destination1,source2:destination2`.
 
 Also. If the destination is not specified, it will be set as equal as the source. For example
 ```bash

--- a/_episodes/08-bonus-episode.md
+++ b/_episodes/08-bonus-episode.md
@@ -15,7 +15,7 @@ keypoints:
 > ## Prerequisites
 > For this lesson, you will need,
 > * Knowledge of Git [SW Carpentry Git-Novice Lesson](https://swcarpentry.github.io/git-novice/)
-> * Knowledge of GitHub CI/CD [HSF Github CI/CD Lesson](https://github.com/hsf-training/hsf-training-cicd-github)
+> * Knowledge of GitHub CI/CD [HSF Github CI/CD Lesson](https://hsf-training.github.io/hsf-training-cicd-github/)
 {: .prereq}
 
 ## Singularity Container for python packages
@@ -52,11 +52,12 @@ As we see, several packages are installed.
 
 ## Publish Singularity images with GitHub Packages and share them!
 
-It is possible to publish singularity images with GitHub packages. To do so, one needs to use GitHub CI/CD. A step-by-step guide is presented here.
+It is possible to publish singularity images with [GitHub packages](https://github.com/features/packages).
+To do so, one needs to use GitHub CI/CD. A step-by-step guide is presented here.
 
 * **Step 1**: Create a GitHub repository and clone it locally.
-* **Step 2**: In the empty repository, make a folder called `.github/workflows`. In this folder we will store the file containing the YAML script for GitHub action, named `singularity-build-deploy.yml` (name doesn't really matter).
-* **Step 3**: In the top directory of your github repo, create a file named `Singularity`.
+* **Step 2**: In the empty repository, make a folder called `.github/workflows`. In this folder we will store the file containing the YAML script for a GitHub workflow, named `singularity-build-deploy.yml` (the name doesn't really matter).
+* **Step 3**: In the top directory of your GitHub repository, create a file named `Singularity`.
 * **Step 4**: Copy-paste the content above and add to the Singularity file. (In principle it is possible to build this image locally, but we will not do that here, as we wish to build it with GitHub CI/CD).
 * **Step 5**: In the `singularity-build-deploy.yml` file, add the following content:
 
@@ -87,7 +88,7 @@ jobs:
 
       - name: Build Container
         run: |
-         sudo -E singularity build container.sif Singularity
+           singularity build container.sif Singularity
 
       - name: Login and Deploy Container
         run: |
@@ -95,7 +96,7 @@ jobs:
            singularity push container.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${tag}
 ```
 
-The above script is designed to build and publish a Singularity image with GitHub packages.
+The above script is designed to build and publish a Singularity image with [GitHub packages](https://github.com/features/packages).
 
 
-* **Step 6**: Optionally add LICENSE and README, and then the repository is good to go.
+* **Step 6**: Add LICENSE and README as recommended in the [SW Carpentry Git-Novice Lesson](https://swcarpentry.github.io/git-novice/), and then the repository is good to go.

--- a/index.md
+++ b/index.md
@@ -5,9 +5,9 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 ---
 Apptainer (formerly known as Singularity) is a free and open-source container platform that allows you to create and run applications in isolated images (also called "containers") in a simple, portable, fast, and secure manner. It performs operating system level virtualization known as containerization. Many container platforms are available, but Apptainer is designed to bring containers and reproducibility to the scientific community and High-Performance Computing (HPC) use cases. Using Apptainer, developers can work in reproducible environments of their choice and design, and these complete environments can be easily copied and executed on other platforms.
 
-An introduction to Singularity/Apptainer, its motivations and applications in HEP.
+This is an introduction to Singularity/Apptainer, its motivations and applications in HEP.
 
-Based on the [Singularity user guide](https://sylabs.io/docs/).
+Based on the [Apptainer user guide](https://apptainer.org/docs/).
 
 <!-- this is an html comment -->
 
@@ -15,8 +15,7 @@ Based on the [Singularity user guide](https://sylabs.io/docs/).
 
 > ## Prerequisites
 > * Basic knowledge of the Unix Shell, e.g., from the [carpentry course](https://swcarpentry.github.io/shell-novice/).
-> * Access to a computing system with Singularity available.
->   Optional: a computer with superuser permissions and Singularity installed
+> * Access to a computing system with Apptainer/Singularity available. It can either be installed locally, or the machine can have user namespaces enabled and access to CVMFS.
 {: .prereq}
 
 {% include curriculum.html %}

--- a/setup.md
+++ b/setup.md
@@ -6,19 +6,27 @@ In this document we use Apptainer and Singularity interchangeably. See the [Intr
 for more details about existing Apptainer and Singularity versions and the differences between them.
 
 Apptainer/Singularity has become popular and usually it is available in the institutional computing resources.
-Check if Singularity is available with
+Check if singularity is available with
 ```bash
 singularity --version
 ```
-You will need a Linux system (including WSL) to run Apptainer/Singularity natively and it’s easiest to install if you have root access.
-If your local computing system does not have Singularity installed, you may
-[request it to your system administrator as suggested here](https://apptainer.org/docs/user/main/quick_start.html#apptainer-on-a-shared-resource).
-If the above is not possible you can also use the CVMFS distribution if you have CVMFS or
-[install from source without root privileges](https://github.com/apptainer/apptainer/blob/main/INSTALL.md).
+If installed, you will see `apptainer version ...` or `singularity version ...`, depending on the flavor installed.
+If it is not in your PATH you may still be able to use it via CVMFS: check if you have user namespaces enabled and CVMFS to run singularity that way:
+```bash
+[[ $(cat /proc/sys/user/max_user_namespaces) -gt 0 ]] && ls /cvmfs/oasis.opensciencegrid.org/mis/ &>/dev/null && { export PATH=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/bin/:"$PATH"; echo "Added to PATH"; singularity --version; } || echo "Unable to run Singularity/Apptainer via CVMFS"
+```
+If this works, it will be added to your path and you will see your singularity/apptainer version.
 
-Preparation of containers with superuser permissions require Singularity in resources with
-access as root. See the [quick installation steps](https://apptainer.org/docs/user/main/quick_start.html#quick-installation)
-if you would like to install Singularity in your computer.
+Otherwise you will need to install or ask to install Apptainer/Singularity.
+You will need a Linux system (including WSL on Windows computers) to run Apptainer/Singularity natively and it’s easiest to
+[install if you have root access](https://apptainer.org/docs/user/main/quick_start.html#quick-installation).
+If your local computing system does not have Apptainer/Singularity installed, you may
+[request it to your system administrator as suggested here](https://apptainer.org/docs/user/main/quick_start.html#apptainer-on-a-shared-resource).
+If the above is not possible and you cannot use the CVMFS distribution you can
+[install from source without root privileges](https://github.com/apptainer/apptainer/blob/main/INSTALL.md).
+If you have user namespaces (`cat /proc/sys/user/max_user_namespaces` is bigger than 0) you have one more option, you can use [cvmfsexec](https://github.com/cvmfs/cvmfsexec) to get CVMFS.
+This is a bit more complex, you can follow the instrictions summarized also in
+[this paper](https://indico.cern.ch/event/885212/contributions/4120683/attachments/2181040/3684201/CernVMWorkshopCvmfsExec20210201.pdf).
 
 
 {% include links.md %}


### PR DESCRIPTION
Updated material to run singularity w/o root privileges
- Updated install/setup instructions
- Using fakeroot it is possible to avoid invoking as root
Fixed also some remaining unclear references to Sylabs and clarified references to the library

2022-11-1 Hackathon contribution
This solves issue #47 