### PR TITLE
Don't install python packages at HOME

### DIFF
--- a/_episodes/08-instances.md
+++ b/_episodes/08-instances.md
@@ -192,7 +192,7 @@ From: ubuntu:20.04
     apt-get update -y
     apt-get install -y python3
     apt-get install -y python3-pip
-    pip install --user notebook  # Don't install as root
+    pip install notebook
 
     apt-get install wget -y
     export DEBIAN_FRONTEND=noninteractive
@@ -275,8 +275,8 @@ is available!
 > >    apt-get update -y
 > >    apt-get install -y python3
 > >    apt-get install -y python3-pip
-> >    pip install --user notebook
-> >    pip install --user uproot
+> >    pip install notebook
+> >    pip install uproot
 > >
 > >%startscript
 > >   jupyter notebook --port 8850


### PR DESCRIPTION
Following the [Apptainer best practices](https://apptainer.org/docs/user/1.0/definition_files.html#best-practices-for-build-recipes), jupyter is installed below `/usr/local` removing the flag `--user`:
```
Apptainer> which jupyter
/usr/local/bin/jupyter
```