### PR TITLE
Replaced singularity references w/ apptainer and set minimum version requirements

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises:
 questions:
 - "What issues motivated the creation of Apptainer/Singularity?"
-- "What are the differences between Docker, Singularity and Apptainer?"
+- "What are the differences between Docker, Apptainer and Singularity?"
 objectives:
 - "Learn the design goals behind Apptainer/Singularity."
 keypoints:
@@ -12,7 +12,7 @@ keypoints:
 - "Single-file based container images facilitates the distribution."
 - "Secure. User inside the container = user outside."
 ---
-<iframe width="427" height="251" src="https://www.youtube.com/embed/v5WbqtRbH6M?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Singularity/Apptainer #1 - Introduction"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/v5WbqtRbH6M?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Apptainer/Singularity #1 - Introduction"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 # Working with containers
 
@@ -61,7 +61,7 @@ a few steps in most of the cases, and its design presents key concepts for the s
 {: .callout}
 
 # Apptainer vs Singularity
-In these lessons you see the name *Apptainer* or *Apptainer/Singularity*, but the command `singularity`.
+In these lessons you see the name *Apptainer* or *Apptainer/Singularity*, and the command `apptainer`.
 As stated in the [move and renaming announcement](https://apptainer.org/news/community-announcement-20211130/), "Singularity IS Apptainer".
 Currently there are three products derived from the original Singularity project from 2015:
 * *Singularity*: commercial software by [Sylabs](https://sylabs.io/).
@@ -71,11 +71,12 @@ As of Fall 2022 all three Apptainer/Singularity versions are compatible and prac
 There is hope that in the future they will join forces, but this is not currently the case.
 To understand how this came to be you can read the [Singularity history on Wikipedia](https://en.wikipedia.org/wiki/Singularity_%28software%29#History).
 
-We are following Apptainer, the most adopted variation in the scientific community.
-But since its previous version was named Singularity and it is providing the `singularity` alias and
-[full compatibility with the previous Singularity environment](https://apptainer.org/docs/user/main/singularity_compatibility.html),
-we'll keep using the `singularity` command and the `SINGULARITY_` and  `SINGULARITYENV_` variable prefixes until
-we are sure that most installation migrated to the most recent version named `apptainer`.
+We are following Apptainer, the most adopted variation in the scientific community, so we are using the `apptainer` command.
+If you are using Singularity or SingularityCE, just replace the command `apptainer` with `singularity` and the
+`APPTAINER_` and  `APPTAINERENV_` variable prefixes  with `SINGULARITY_` and  `SINGULARITYENV_`.
+ But since its previous version was named Singularity and it
+If you have older scripts still using the `singularity` command they will work also in Apptainer because it is providing the `singularity` alias
+and [full compatibility with the previous Singularity environment](https://apptainer.org/docs/user/main/singularity_compatibility.html).
 
 # Documentation
 

--- a/_episodes/02-running-containers.md
+++ b/_episodes/02-running-containers.md
@@ -3,29 +3,29 @@ title: "Containers and Images"
 teaching: 20
 exercises: 5
 questions:
-- "How to pull Singularity images from the libraries?"
+- "How to pull Apptainer images from the libraries?"
 - "How to run commands inside the containers?"
 objectives:
-- "Learn to search and pull images from the Singularity library and Docker Hub."
+- "Learn to search and pull images from the Sylabs Singularity library and Docker Hub."
 - "Interact with the containers using the command-line interface."
 keypoints:
 - "A container can be started from a local `.sif` or directly with the URL of the image."
-- "Singularity is also compatible with Docker images, providing access to the large collection of images hosted by Docker Hub."
-- Get a shell inside of your container with `singularity shell <path/URL to image>`
-- Execute a command inside of your container with `singularity exec <path/URL> <command>`
+- "Apptainer is also compatible with Docker images, providing access to the large collection of images hosted by Docker Hub."
+- Get a shell inside of your container with `apptainer shell <path/URL to image>`
+- Execute a command inside of your container with `apptainer exec <path/URL> <command>`
 - Bind outside directories with `--bind`
 ---
-<iframe width="427" height="251" src="https://www.youtube.com/embed/puSbnD415Ow?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Singularity/Apptainer #2 - Containers and Images"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/puSbnD415Ow?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Apptainer/Singularity #2 - Containers and Images"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-# The Singularity Command Line Interface
+# The Apptainer Command Line Interface
 
-Singularity provides a command-line interface (CLI) to interact with the containers. You can search, build or run
+Apptainer provides a command-line interface (CLI) to interact with the containers. You can search, build or run
 containers in a single line.
 
 You can check the available options and subcommands using `--help`:
 
 ```bash
-singularity --help
+apptainer --help
 ```
 
 # Downloading Images
@@ -39,21 +39,21 @@ Sylabs, the developers of one Singularity flavor, hosts a public image registry,
 The Linux Foundation flavor, Apptainer, does not point by default to the Sylab registry as previous versions did.
 You can change that running these commands (documented [here](https://apptainer.org/docs/user/main/endpoint.html#restoring-pre-apptainer-library-behavior)):
 ```bash
-singularity remote add --no-login SylabsCloud cloud.sycloud.io
+apptainer remote add --no-login SylabsCloud cloud.sycloud.io
 ```
 ~~~
 INFO:    Remote "SylabsCloud" added.
 ~~~
 {: .output}
 ```bash
-singularity remote use SylabsCloud
+apptainer remote use SylabsCloud
 ```
 ~~~
 INFO:    Remote "SylabsCloud" now in use.
 ~~~
 {: .output}
 ```bash
-singularity remote list
+apptainer remote list
 ```
 ~~~
 Cloud Services Endpoints
@@ -72,7 +72,7 @@ and shows information about groups and collections. For example:
 
 ```bash
 # this command can take around a minute to complete
-singularity search centos7
+apptainer search centos7
 ```
 
 ~~~
@@ -90,17 +90,17 @@ Found 15 containers for 'centos7'
 
 Downloading an image from the Container Library is pretty straightforward:
 ```bash
-singularity pull library://gmk/default/centos7-devel
+apptainer pull library://gmk/default/centos7-devel
 ```
 and the image is stored locally as a `.sif` file (`centos7-devel_latest.sif`, in this case).
 
 > ## Docker Images
 >
-> Fortunately, Singularity is also compatible with Docker images. There are many more registries with Docker images.
+> Fortunately, Apptainer is also compatible with Docker images. There are many more registries with Docker images.
 > [Docker Hub](https://hub.docker.com/) is one of the largest libraries available,
 > and any image hosted on the hub can be easily downloaded with the `docker://` URL as reference:
 > ```bash
-> singularity pull docker://centos:centos7
+> apptainer pull docker://centos:centos7
 > ```
 {: .callout}
 
@@ -114,18 +114,18 @@ environment and how to execute directly a command.
 The `shell` command initializes a new interactive shell inside the container.
 
 ```bash
-singularity shell centos7-devel_latest.sif
+apptainer shell centos7-devel_latest.sif
 ```
 
 ~~~
-Singularity>
+Apptainer>
 ~~~
 {: .output}
 In this case, the container works as a lightweight virtual machine in which you can execute commands.
 Remember, inside the container you have the same user and permissions.
 
 ```bash
-Singularity> id
+Apptainer> id
 ```
 
 ~~~
@@ -136,24 +136,24 @@ uid=1001(myuser) gid=1001(myuser) groups=1001(myuser),500(myothergroup)
 Now quit the container by typing
 
 ```bash
-Singularity> exit
+Apptainer> exit
 ```
 
 or hitting `Ctrl + D`.
-Note that when exiting from the singularity image all the running processes are killed (stopped).
+Note that when exiting from the Apptainer image all the running processes are killed (stopped).
 Changes saved into bound directories are preserved. By default anything else in the container is lost (we'll see later about writable images).
 
 ## Bound directories
 
-When an outside directory is accessible also inside Singularity we say it is *bound*, or bind mounted. The path to access it
+When an outside directory is accessible also inside Apptainer we say it is *bound*, or bind mounted. The path to access it
 may differ but anything you do to its content outside is visible inside and vice-versa.
-By default, Singularity binds the home of the user, `/tmp` and `$PWD` into the container. This means your files
+By default, Apptainer binds the home of the user, `/tmp` and `$PWD` into the container. This means your files
 at `hostname:~/` are accessible inside the container. You can specify additional bind mounts using the `--bind` option.
 For example, let's say `/cvmfs` is available in the host, and you would like to have access to CVMFS inside the
-container (here, *host* refers to the computer/server that you are running singularity on). Then let's do
+container (here, *host* refers to the computer/server that you are running apptainer on). Then let's do
 
 ```bash
-singularity shell --bind /cvmfs:/mnt centos7-devel_latest.sif
+apptainer shell --bind /cvmfs:/mnt centos7-devel_latest.sif
 ```
 
 Here, the colon `:` separates the path to the directory on the host (`/cvmfs/`) from the mounting point (`/mnt/`) inside of the
@@ -164,7 +164,7 @@ More information on binding is provided [later]({{ site.baseurl }}/07-file-shari
 Let's check that this works:
 
 ~~~
-Singularity> ls /mnt/cms.cern.ch
+Apptainer> ls /mnt/cms.cern.ch
 bin                        etc                  SITECONF           slc7_aarch64_gcc530
 bootstrap.sh               external             slc5_amd64_gcc434  slc7_aarch64_gcc700
 ...
@@ -175,12 +175,12 @@ bootstrap.sh               external             slc5_amd64_gcc434  slc7_aarch64_
 > Each of the different commands to set a container from a local `.sif` also accepts the URL of the image
 > as input. For example, starting a shell with Scientific Linux 6 is as easy as
 > ```bash
-> singularity shell docker://sl:6
+> apptainer shell docker://sl:6
 > ```
 > ~~~
 > 2020/12/17 21:42:46  info unpack layer: sha256:e0a6b33502f39d76f7c70213fa5b91688a46c2217ad9ba7a4d1690d33c6675ef
 > INFO:    Creating SIF file...
-> Singularity>
+> Apptainer>
 > ~~~
 > {: .output}
 {: .callout}
@@ -192,7 +192,7 @@ Let's use the official [Docker image of ROOT](https://hub.docker.com/r/rootproje
 inside a container:
 
 ```bash
-singularity exec docker://rootproject/root root -b
+apptainer exec docker://rootproject/root root -b
 ```
 
 ~~~
@@ -214,7 +214,7 @@ root [0]
 {: .output}
 
 And just like that, ROOT can be used in any laptop, large-scale cluster or grid system
-with Singularity available.
+with Apptainer available.
 
 > ## Execute Python with PyROOT available
 >
@@ -223,7 +223,7 @@ with Singularity available.
 > > ## Solution
 > >
 > > ```bash
-> > singularity exec docker://rootproject/root python3
+> > apptainer exec docker://rootproject/root python3
 > > ```
 > >
 > > ~~~

--- a/_episodes/04-building-containers.md
+++ b/_episodes/04-building-containers.md
@@ -12,10 +12,10 @@ keypoints:
 - "Superuser permissions are required to build containers if you need to install packages or manipulate the operating system."
 - "Use interactive builds only for development and tests, use definition files for production or publicly distributed containers."
 ---
-<iframe width="427" height="251" src="https://www.youtube.com/embed/aqjxxc2kMlU?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Singularity/Apptainer #3 - Building Containers"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/aqjxxc2kMlU?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Apptainer/Singularity #3 - Building Containers"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Running containers from the available public images is not the only option. In many cases, it is required to modify
-an image or even to create a new one from scratch. For such purposes, Singularity provides the command `build`,
+an image or even to create a new one from scratch. For such purposes, Apptainer provides the command `build`,
 defined in the documentation as the _Swiss army knife_ of container creation.
 
 The usual workflow is to prepare and test a container in a build environment (like your laptop),
@@ -26,8 +26,8 @@ If you want to distribute the container or use it in production, then we recomme
 This ensures the greatest possibility of reproducibility and transparency.
 
 <figure>
-  <img src="https://journals.plos.org/plosone/article/figure/image?size=large&id=10.1371/journal.pone.0177459.g001" alt="Singularity usage workflow"/>
-  <figcaption>'Singularity usage workflow' via <i>Kurtzer GM, Sochat V, Bauer MW (2017) Singularity: Scientific containers for mobility of compute. PLoS ONE 12(5): e0177459. <a href="https://doi.org/10.1371/journal.pone.0177459">https://doi.org/10.1371/journal.pone.0177459</a></i></figcaption>
+  <img src="https://journals.plos.org/plosone/article/figure/image?size=large&id=10.1371/journal.pone.0177459.g001" alt="Apptainer/Singularity usage workflow"/>
+  <figcaption>'Apptainer/Singularity usage workflow' via <i>Kurtzer GM, Sochat V, Bauer MW (2017) Singularity: Scientific containers for mobility of compute. PLoS ONE 12(5): e0177459. <a href="https://doi.org/10.1371/journal.pone.0177459">https://doi.org/10.1371/journal.pone.0177459</a></i></figcaption>
 </figure>
 
 ## Build a container in an interactive session
@@ -37,7 +37,7 @@ more convenient the use of a _sandbox_, which can be easily modified.
 
 The command `build` provides a flag `--sandbox` that will create a writable directory, `myCentOS7`, in your work directory:
 ```bash
-singularity build --sandbox myCentOS7 docker://centos:centos7
+apptainer build --sandbox myCentOS7 docker://centos:centos7
 ```
 
 > ## Notes on shared file systems like AFS
@@ -53,8 +53,8 @@ of CentOS7.
 To initialize an interactive session use the `shell` command. And to write files within the sandbox directory use the `--writable` option.
 Finally, the installation of new components will require superuser access inside the container, so use also the `--fakeroot` option, unless you are already root also outside.
 ```bash
-singularity shell --writable --fakeroot myCentOS7
-Singularity> whoami
+apptainer shell --writable --fakeroot myCentOS7
+Apptainer> whoami
 ```
 ~~~
 root
@@ -70,8 +70,8 @@ If you get an error when using `--fakeroot` have a look at the [fakeroot documen
 As an example, let's create a container with Pythia8 available using the `myCentOS7` sandbox.
 First, we need to install the development tools (remember that in this interactive session we are superuser):
 ```bash
-Singularity> yum groupinstall 'Development Tools'
-Singularity> yum install python3-devel
+Apptainer> yum groupinstall 'Development Tools'
+Apptainer> yum install python3-devel
 ```
 Where `yum` is the [package manager used in RHEL distributions](https://en.wikipedia.org/wiki/Yum_(software))
 (like CentOS).
@@ -81,32 +81,32 @@ installation steps described in the [Pythia website](https://pythia.org/).
 Here is a summary of the commands you will need (you may need to adjust link and commands if there is a new Pythia version):
 
 ```bash
-Singularity> mkdir /opt/pythia && cd /opt/pythia
-Singularity> curl -o pythia8307.tgz https://pythia.org/download/pythia83/pythia8307.tgz
-Singularity> tar xvfz pythia8307.tgz
-Singularity> ln -s pythia8307 pythia8
+Apptainer> mkdir /opt/pythia && cd /opt/pythia
+Apptainer> curl -o pythia8307.tgz https://pythia.org/download/pythia83/pythia8307.tgz
+Apptainer> tar xvfz pythia8307.tgz
+Apptainer> ln -s pythia8307 pythia8
 ```
 
 To enable the Python interface, we add the flag `--with-python-include` during the configuration, pointing to the
 location of the Python headers:
 
 ```bash
-Singularity> cd pythia8307
-Singularity> ./configure --with-python-include=/usr/include/python3.6m/
-Singularity> make
+Apptainer> cd pythia8307
+Apptainer> ./configure --with-python-include=/usr/include/python3.6m/
+Apptainer> make
 
-Singularity> exit
+Apptainer> exit
 ```
 
 Now, open an interactive session with your user (no `--fakeroot`). You can use now the container with Pythia8 ready in a
 few steps. Let's use the Python interface:
 
 ```bash
-singularity shell myCentOS7
+apptainer shell myCentOS7
 
-Singularity> export PYTHONPATH=/opt/pythia/pythia8/lib:$PYTHONPATH
-Singularity> export LD_LIBRARY_PATH=/opt/pythia/pythia8/lib:$LD_LIBRARY_PATH
-Singularity> python3
+Apptainer> export PYTHONPATH=/opt/pythia/pythia8/lib:$PYTHONPATH
+Apptainer> export LD_LIBRARY_PATH=/opt/pythia/pythia8/lib:$LD_LIBRARY_PATH
+Apptainer> python3
 
 >>> import pythia8
 >>> pythia = pythia8.Pythia()
@@ -143,17 +143,17 @@ We will automate this in the next section.
 > >
 > > Start from the [Python 3.9 Docker image](https://hub.docker.com/_/python) and create the `myPython` sandbox:
 > > ```bash
-> > singularity build --sandbox myPython docker://python:3.9
-> > singularity shell myPython
+> > apptainer build --sandbox myPython docker://python:3.9
+> > apptainer shell myPython
 > > ```
 > > Once inside the container, you can install [Uproot](https://uproot.readthedocs.io/en/latest/index.html).
 > > ```bash
-> > Singularity> python3 -m pip install --upgrade pip
-> > Singularity> python3 -m pip install uproot awkward
+> > Apptainer> python3 -m pip install --upgrade pip
+> > Apptainer> python3 -m pip install uproot awkward
 > > ```
 > > Exit the container and use it as you like:
 > > ```bash
-> > singularity exec myPython python -c "import uproot; print(uproot.__doc__)"
+> > apptainer exec myPython python -c "import uproot; print(uproot.__doc__)"
 > > ```
 > > ~~~
 > > Uproot: ROOT I/O in pure Python and NumPy.
@@ -161,7 +161,7 @@ We will automate this in the next section.
 > > ~~~
 > > {: .output}
 > > Notice how we did not need neither `--writable ` nor `--fakeroot` for the installation, but everything worked fine since pip installs user packages in the user $HOME directory.
-> > In addition, Singularity/Apptainer by default mounts the user home directory as read+write, even if the container is read-only.
+> > In addition, Apptainer/Singularity by default mounts the user home directory as read+write, even if the container is read-only.
 > > This is why a _sandbox_ is great to test and experiment locally, but should not be used for containers that will be shared or deployed. Manual changes and local directories are difficult to reproduce and control. Once you are happy with the content, you should use definition files, described in the next episode.
 > {: .solution}
 {: .challenge}

--- a/_episodes/05-definition-files.md
+++ b/_episodes/05-definition-files.md
@@ -7,16 +7,16 @@ questions:
 objectives:
 - "Create a container from a definition file."
 keypoints:
-- "A Singularity definition file provides an easy way to build and deploy containers."
+- "An Apptainer definition file provides an easy way to build and deploy containers."
 ---
-<iframe width="427" height="251" src="https://www.youtube.com/embed/v2ZJ0L3TF48?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Singularity/Apptainer #4 - Definition files"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/v2ZJ0L3TF48?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Apptainer/Singularity #4 - Definition files"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 As shown in the previous chapter, building containers with an interactive session may take several steps, and it can
 become as complicated as the setup is needed.
-A Singularity definition file provides an easy way to build and deploy containers.
+An Apptainer definition file provides an easy way to build and deploy containers.
 
 
-## Hello World Singularity
+## Hello World Apptainer
 
 The following recipe shows how to build a hello-world container, and run the container on your local computer.
 
@@ -37,19 +37,19 @@ The following recipe shows how to build a hello-world container, and run the con
   # Print Hello world when the image is loaded
   ```
 
-    In the above script, the first line - `BootStrap: docker` indicates that singularity will use the docker protocol to retrieve the base OS to start the image.
-The `From: ubuntu:20.04` is given to singularity to start from a specific image/OS in Docker Hub.
-Any content within the  `%runscript` will be written to a file that is executed when one runs the singularity image.
+    In the above script, the first line - `BootStrap: docker` indicates that apptainer will use the docker protocol to retrieve the base OS to start the image.
+The `From: ubuntu:20.04` is given to apptainer to start from a specific image/OS in Docker Hub.
+Any content within the  `%runscript` will be written to a file that is executed when one runs the apptainer image.
 The `echo "Hello World"` command will print the `Hello World` on the terminal.
 Finally the `#` hash is used to include comments within the definition file.
 
 - Step 3: Build the image
 
   ```bash
-  singularity build hello-world.sif hello-world.def
+  apptainer build hello-world.sif hello-world.def
   ```
 
-    The `hello-world.sif` file specifies the name of the output file that is built when using the `singularity build` command.
+    The `hello-world.sif` file specifies the name of the output file that is built when using the `apptainer build` command.
 
 - Step 4: Run the image
 
@@ -57,11 +57,11 @@ Finally the `#` hash is used to include comments within the definition file.
   ./hello-world.sif
   ```
 
-### Deleting Singularity image
-To delete the hello-world Singularity image, simply delete the `hello-world.sif` file.
+### Deleting Apptainer image
+To delete the hello-world Apptainer image, simply delete the `hello-world.sif` file.
 
-> ## `singularity delete`
-> Note that there is also a `singularity delete` command, but it is to delete an image from a remote library.
+> ## `apptainer delete`
+> Note that there is also a `apptainer delete` command, but it is to delete an image from a remote library.
 > To learn more about using remote endpoints and pulling and pushing images from or to libraries, read
 > [Remote Endpoints](https://apptainer.org/docs/user/main/endpoint.html) and [Library API Registries](https://apptainer.org/docs/user/main/library_api.html).
 {: .callout}
@@ -116,21 +116,21 @@ steps that we would follow to install ROOT with a precompiled binary in an inter
 Notice that the binary used corresponds with the Ubuntu version defined at the second line.
 * `%environment` is used to define environment variables available inside the container. Here we are setting the env
 variables required to execute ROOT and PyROOT.
-* Singularity containers can be executable. `%runscript` define the actions to take when the container is executed.
+* Apptainer containers can be executable. `%runscript` define the actions to take when the container is executed.
 To illustrate the functionality, we will just run [rf101_basics.py](https://root.cern/doc/master/rf101__basics_8py.html)
 from the RooFit tutorial.
 * `%labels` add custom metadata to the container.
-* `%help` it is the container documentation: what it is and how to use it. Can be displayed using `singularity run-help`
+* `%help` it is the container documentation: what it is and how to use it. Can be displayed using `apptainer run-help`
 
 Save this definition file as `rootInUbuntu.def`. To build the container, just provide the definition file as argument
 (executing as superuser):
 ```bash
-singularity build rootInUbuntu.sif rootInUbuntu.def
+apptainer build rootInUbuntu.sif rootInUbuntu.def
 ```
 
 
-Then, an interactive shell inside the container can be initialized with `singularity shell`, or
-a command executed with `singularity exec`. A third option is execute the actions defined inside `%runscript`
+Then, an interactive shell inside the container can be initialized with `apptainer shell`, or
+a command executed with `apptainer exec`. A third option is execute the actions defined inside `%runscript`
 simply by calling the container as an executable
 
 ```bash
@@ -171,7 +171,7 @@ A few [best practices for your containers](https://apptainer.org/docs/user/1.0/d
 > ## Deploying your containers
 > Keep in mind that, while building a container may be time consuming, the execution can be immediate and anywhere your image is available.
 > Once your container is built with the requirements of your analysis, you can deploy it in a large cluster and execute it
-> as far as Singularity is available on the site.
+> as far as Apptainer is available on the site.
 >
 > Libraries like [Sylabs Cloud Library](https://cloud.sylabs.io/library) ease the distribution of images.
 > Organizations like OSG provide instructions to [use available images](https://portal.osg-htc.org/documentation/htc_workloads/using_software/containers/)
@@ -228,7 +228,7 @@ and [distribute custom images via CVMFS](https://portal.osg-htc.org/documentatio
 > > Build your container executing
 > >
 > > ```bash
-> > singularity build pythiaInCentos7.sif myPythia8.def
+> > apptainer build pythiaInCentos7.sif myPythia8.def
 > > ```
 > >
 > > And finally, execute the container to run [`main01.py`](https://gitlab.com/Pythia8/releases/-/blob/pythia8307/examples/main01.py)

--- a/_episodes/07-file-sharing.md
+++ b/_episodes/07-file-sharing.md
@@ -9,11 +9,11 @@ objectives:
 - "Learn about the bind paths included automatically in all containers."
 keypoints:
 - "Bind mounts allow reading and writing files within the container."
-- "In Singularity, you have same owner and permissions for files inside and outside the container."
-- "Some paths are mounted by default by Singularity."
+- "In Apptainer, you have same owner and permissions for files inside and outside the container."
+- "Some paths are mounted by default by Apptainer."
 - "Additional directories to bind can be defined using the `--bind` option or the environment variable `$SINGULARITY_BIND`."
 ---
-<iframe width="427" height="251" src="https://www.youtube.com/embed/E-vlXHEsacE?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Singularity/Apptainer #5 - Sharing files between host and container"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/E-vlXHEsacE?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Apptainer/Singularity #5 - Sharing files between host and container"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 One of the key features about containers is the isolation of the processes running inside them. It means,
 files on the host system are not accessible within the container.
@@ -21,17 +21,17 @@ However, it is
 very common that some files on the host system are needed inside the container, or you want to write files from the
 container to some directory in the host.
 
-We have already used the option `--bind` earlier in the module when exploring the options available to run Singularity
+We have already used the option `--bind` earlier in the module when exploring the options available to run Apptainer
 containers. In this chapter we will explore further options to bind directories from your host system to directories
 within your container.
 
-Remember that in Singularity, your user outside is the same inside the container (except when using fakeroot).
+Remember that in Apptainer, your user outside is the same inside the container (except when using fakeroot).
 And the same happens with permissions and ownership for files in bind directories.
 
 ## Bind paths included by default
 
-For each container executed, Singularity binds automatically some directories by default, and other defined
-by the system admin in the Singularity configuration. By default, Singularity binds:
+For each container executed, Apptainer binds automatically some directories by default, and other defined
+by the system admin in the Apptainer configuration. By default, Apptainer binds:
 * The user's home directory ($HOME)
 * The current directory when the container is executed ($PWD)
 * System-defined paths: `/tmp`, `/proc`, `/dev`, etc.
@@ -48,14 +48,14 @@ pwd
 {: .output}
 Open a shell inside the container and try to use `pwd` again
 ```bash
-singularity shell rootInUbuntu.sif
+apptainer shell rootInUbuntu.sif
 
-Singularity> pwd
+Apptainer> pwd
 ```
 ~~~
 /home/myuser/somedirectory
 ~~~
-you will notice that the files stored on the host are located inside the container! As we explained above, Singularity
+you will notice that the files stored on the host are located inside the container! As we explained above, Apptainer
 mounts automatically your `$HOME` inside the container.
 
 > ## Disabling system binds
@@ -69,7 +69,7 @@ mounts automatically your `$HOME` inside the container.
 
 Try this time with
 ```bash
-singularity shell --no-mount home rootInUbuntu.sif
+apptainer shell --no-mount home rootInUbuntu.sif
 ```
 and you will notice that `$HOME` is not mounted anymore
 ```bash
@@ -82,8 +82,8 @@ ls: cannot access '/home/myuser': No such file or directory
 
 ## User-defined bind paths
 
-Singularity provides mechanisms to specify additional binds when executing a container via command-line
-or environment variables. Singularity offers a complex set of mechanism for binds or other mounts.
+Apptainer provides mechanisms to specify additional binds when executing a container via command-line
+or environment variables. Apptainer offers a complex set of mechanism for binds or other mounts.
 Here we present the main points, refer to the
 [Bind Paths and Mounts documentation](https://apptainer.org/docs/user/main/bind_paths_and_mounts.html) for more.
 
@@ -103,7 +103,7 @@ echo "MUONMASS=105.66 MeV" > $HOME/mydata/muonMass.txt
 It is very, very important in your analysis workflow to know the mass of the muon, right? It may have sense to put the data
 in a high-level directory within the container, like `/data`
 ```bash
-singularity shell --bind $HOME/mydata:/data rootInUbuntu.sif
+apptainer shell --bind $HOME/mydata:/data rootInUbuntu.sif
 ```
 This will bind the directory `mydata/` from the host as `/data` inside the container:
 ```bash
@@ -121,7 +121,7 @@ i.e. using the syntax `source1:destination1,source2:destination2`.
 
 Also. If the destination is not specified, it will be set as equal as the source. For example
 ```bash
-singularity shell --bind /cvmfs rootInUbuntu.sif
+apptainer shell --bind /cvmfs rootInUbuntu.sif
 ```
 Will mount `/cvmfs` inside the container. Try it!
 
@@ -136,13 +136,13 @@ Will mount `/cvmfs` inside the container. Try it!
 
 ### Bind with environment variables
 
-If the environment variable `$SINGULARITY_BIND` is defined, singularity will bind inside ANY container
+If the environment variable `$APPTAINER_BIND` is defined, apptainer will bind inside ANY container
 the directories specified in the format `source`, with the destination being optional (in the same way as using
 `--bind`). For example:
 ```bash
 export SINGULARITY_BIND="/cvmfs"
 ```
-will bind CVMFS to all your Singularity containers (`/cvmfs` must be available in the host, of course).
+will bind CVMFS to all your Apptainer containers (`/cvmfs` must be available in the host, of course).
 
 You can also bind multiple directories using commas between each `source:destination`.
 

--- a/_episodes/08-instances.md
+++ b/_episodes/08-instances.md
@@ -1,5 +1,5 @@
 ---
-title: "Singularity/Apptainer instances"
+title: "Apptainer/Singularity instances"
 teaching: 60
 exercises: 10
 questions:
@@ -9,34 +9,34 @@ objectives:
 - "Run containers in a detached mode to keep services up."
 - "Deploy instances via definition files."
 keypoints:
-- Instances allow to setup services via Singularity images or definition files.
-- Code provided in Jupyter notebooks can be accompanied by a Singularity/Apptainer image with the environment needed for its execution, ensuring the reproducibility of the results.
+- Instances allow to setup services via Apptainer images or definition files.
+- Code provided in Jupyter notebooks can be accompanied by a Apptainer/Singularity image with the environment needed for its execution, ensuring the reproducibility of the results.
 ---
-<iframe width="427" height="251" src="https://www.youtube.com/embed/10s8yUScYM8" title="Intro to Singularity/Apptainer #6 - Instances"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/10s8yUScYM8" title="Intro to Apptainer/Singularity #6 - Instances"  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-As we have studied in previous chapters, commands such as `run` and `shell` allocate Singularity/Apptainer
+As we have studied in previous chapters, commands such as `run` and `shell` allocate Apptainer/Singularity
 containers in the foreground, stopping any process running inside the container after logout. This behavior
 suits the use case of containers for executing interactive commands in a well-defined environment, but there
 are cases when running processes in the background is convenient. For example, when a web application like a
 Jupyter notebook is deployed inside a container, it is desired to keep the container up while it waits for connections
 from the web browser.
 
-Singularity provides the concept of _instances_ to deploy services in the background. While Docker is a common
-choice of tool for setting services, Singularity has the advantage of working without requiring any special permissions
+Apptainer provides the concept of _instances_ to deploy services in the background. While Docker is a common
+choice of tool for setting services, Apptainer has the advantage of working without requiring any special permissions
 (like when you are working in a cluster provided by your university/laboratory).
 In this chapter we will learn the basics about their capabilities and some use cases as examples.
 
 ## Instances from image files
 
-To start an instance, Singularity provide the command `instance`. To exemplify, let's pull the CentOS image used
+To start an instance, Apptainer provides the command `instance`. To exemplify, let's pull the CentOS image used
 in previous chapters
 ```bash
-singularity pull docker://centos:centos7
+apptainer pull docker://centos:centos7
 ```
 
 The image must be started in the following way:
 ```bash
-singularity instance start centos_centos7.sif mycentos7
+apptainer instance start centos_centos7.sif mycentos7
 ```
 In this example, the `.sif` is the image downloaded from Dockerhub, and `mycentos7` is the name that we have
 assigned to the instance. Instead of opening a shell session or executing a command, the container is running in
@@ -44,7 +44,7 @@ the background.
 
 Confirm that the instance is running using the `instance list` command
 ```bash
-singularity instance list
+apptainer instance list
 ```
 ~~~
 INSTANCE NAME    PID      IP    IMAGE
@@ -56,12 +56,12 @@ To interact with the instance, the commands `exec` and `shell` are available. Th
 `instance://name`.
 For example, to open a shell inside the CentOS instance:
 ```bash
-singularity shell instance://mycentos7
+apptainer shell instance://mycentos7
 ```
 
 Remember that exiting the shell instance will not stop the container. For doing so, use `instance stop`:
 ```bash
-singularity instance stop mycentos7
+apptainer instance stop mycentos7
 ```
 You can confirm the instance doesn't exist with `instance list`.
 
@@ -73,7 +73,7 @@ You can confirm the instance doesn't exist with `instance list`.
 > an interactive session are available. For example, if you want a directory mounted inside the instance, use the
 > `--bind` option:
 > ```bash
-> singularity instance start --bind /home/user/mydata:/data centos_centos7.sif mycentos7
+> apptainer instance start --bind /home/user/mydata:/data centos_centos7.sif mycentos7
 > ```
 > binding the directory `mydata/` from the host as `/data` inside the instance.
 {: .callout}
@@ -81,7 +81,7 @@ You can confirm the instance doesn't exist with `instance list`.
 
 ## A web server as an instance
 
-One of the main purposes of the Singularity instances is deploying services with customized environments. Before moving
+One of the main purposes of the Apptainer instances is deploying services with customized environments. Before moving
 to more complex use cases, let's start with a basic example: a web service showing a HTML with a message.
 
 Let's write a basic `index.html` file as:
@@ -117,7 +117,7 @@ From: ubuntu:20.04
    cd /tmp
    python3.9 -m http.server 8850
 ```
-If you recall the chapter about [definition files](https://hsf-training.github.io/hsf-training-singularity-webpage/05-definition-files/index.html),
+If you recall the chapter about [definition files]({{ page.root }}{% link _episodes/05-definition-files.md %}),
 this definition file will pull the official Ubuntu image from Dockerhub, and will install Python3.9.
 In addition, it copies `index.html` in `/tmp` **inside** the container. When the instance starts, commands specified on
 `%startscript` are executed. On this example, `http.server` will be executed, serving a page in the port 8850 (you can
@@ -126,14 +126,14 @@ use any other port if 8850 is busy with another service).
 Let's build an image from the definition. Remember that building images requires either superuser permissions or
 using the flag `--fakeroot` as
 ```bash
-singularity build --fakeroot basicServer.sif basicServer.def
+apptainer build --fakeroot basicServer.sif basicServer.def
 ```
 
 Now, let's start an instance named `myWebService` with the image that we just built
 ```bash
-singularity instance start --no-mount tmp basicServer.sif myWebService
+apptainer instance start --no-mount tmp basicServer.sif myWebService
 ```
-Reminder from the previous chapter: with `--no-mount tmp` we are asking Singularity to NOT bind `/tmp` from the host
+Reminder from the previous chapter: with `--no-mount tmp` we are asking Apptainer to NOT bind `/tmp` from the host
 to the instance (it is mounted by default), we use instead an isolated `/tmp` inside the instance where index.html has
 been copied.
 
@@ -155,7 +155,7 @@ curl http://localhost:8850
 ~~~
 {: .output}
 
-If you are executing Singularity locally, try to open http://localhost:8850.
+If you are executing Apptainer locally, try to open http://localhost:8850.
 
 > ## SSH tunneling
 >
@@ -183,7 +183,7 @@ As an example of the capabilities of instances as services, let's extend our def
 Jupyter notebook server with a customized environment.
 
 What if we provide a Jupyter notebook ready to use ROOT? If you remember our example from the
-[definition files chapter](https://hsf-training.github.io/hsf-training-singularity-webpage/05-definition-files/index.html),
+[definition files chapter]({{ page.root }}{% link _episodes/05-definition-files.md %}),
 at this point it must be almost straightforward:
 ```
 Bootstrap: docker
@@ -214,15 +214,15 @@ From: ubuntu:20.04
 
 Save the definition file as `jupyterWithROOT.def`, and let's build an image called `jupyterWithROOT.sif`
 ```bash
-singularity build --fakeroot jupyterWithROOT.sif jupyterWithROOT.def
+apptainer build --fakeroot jupyterWithROOT.sif jupyterWithROOT.def
 ```
 Now, start an instance named `mynotebook` with our brand-new image
 ```bash
-singularity instance start jupyterWithROOT.sif mynotebook
+apptainer instance start jupyterWithROOT.sif mynotebook
 ```
 and confirm that the instance is up
 ```bash
-singularity instance list
+apptainer instance list
 ```
 ~~~
 INSTANCE NAME    PID      IP    IMAGE
@@ -234,7 +234,7 @@ If you go to http://localhost:8850 (with SSH tunneling if needed), you will find
 Jupyter webapp will ask for an access token. Fortunately, you can get the token listing the URL of active servers using
 the `jupyter notebook list` command. To execute the command inside the instance, use `sigularity exec`:
 ```bash
-singularity exec instance://notebook jupyter notebook list
+apptainer exec instance://notebook jupyter notebook list
 ```
 ~~~
 Currently running servers:
@@ -255,14 +255,14 @@ h.Draw()
 c.Draw()
 ```
 
-The bottom line: with any Jupyter notebook that you write, you can provide a Singularity image that will
+The bottom line: with any Jupyter notebook that you write, you can provide an Apptainer image that will
 set the environment required to execute the cells. It doesn't matter if yourself or someone else comes in one, five,
-ten years, your code will work independently of the software available in your computer as far as Singularity/Apptainer
+ten years, your code will work independently of the software available in your computer as far as Apptainer/Singularity
 is available!
 
 > ## A Jupyter notebook with Uproot available
 >
-> Can you setup a Jupyter notebook server with [Uproot](https://uproot.readthedocs.io/en/latest/index.html) available in Singularity?
+> Can you setup a Jupyter notebook server with [Uproot](https://uproot.readthedocs.io/en/latest/index.html) available in Apptainer?
 >
 > Hint: Uproot can be installed using `pip`.
 >

--- a/_episodes/09-bonus-episode.md
+++ b/_episodes/09-bonus-episode.md
@@ -1,15 +1,15 @@
 ---
-title: "Bonus Episode: Building and deploying a Singularity container to Github Packages"
+title: "Bonus Episode: Building and deploying an Apptainer container to Github Packages"
 teaching: 40
 exercises: 0
 questions:
-- How to build singularity container for python packages?
-- How to share singularity images?
+- How to build apptainer container for python packages?
+- How to share apptainer images?
 objectives:
-- To be able to build a singularity container and share it via GitHub packages
+- To be able to build an apptainer container and share it via GitHub packages
 keypoints:
--  Python packages can be installed in singularity images along with ubuntu packages.
--  It is possible to publish and share singularity images over github packages.
+-  Python packages can be installed in apptainer images along with ubuntu packages.
+-  It is possible to publish and share apptainer images over github packages.
 ---
 
 > ## Prerequisites
@@ -18,11 +18,11 @@ keypoints:
 > * Knowledge of GitHub CI/CD [HSF Github CI/CD Lesson](https://hsf-training.github.io/hsf-training-cicd-github/)
 {: .prereq}
 
-<iframe width="427" height="251" src="https://www.youtube.com/embed/BRRaSsrK7-k" title="Intro to Singularity/Apptainer #7 - Bonus episode" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/BRRaSsrK7-k" title="Intro to Apptainer/Singularity #7 - Bonus episode" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-## Singularity Container for python packages
+## Apptainer Container for python packages
 
-Python packages can be installed using a Singularity image. The following example illustrates how to write a definition file for building an image containing python packages.
+Python packages can be installed using an Apptainer image. The following example illustrates how to write a definition file for building an image containing python packages.
 
 ```text
 BootStrap: docker
@@ -52,20 +52,20 @@ From: ubuntu:20.04
 As we see, several packages are installed.
 
 
-## Publish Singularity images with GitHub Packages and share them!
+## Publish Apptainer images with GitHub Packages and share them!
 
-It is possible to publish singularity images with [GitHub packages](https://github.com/features/packages).
+It is possible to publish apptainer images with [GitHub packages](https://github.com/features/packages).
 To do so, one needs to use GitHub CI/CD. A step-by-step guide is presented here.
 
 * **Step 1**: Create a GitHub repository and clone it locally.
-* **Step 2**: In the empty repository, make a folder called `.github/workflows`. In this folder we will store the file containing the YAML script for a GitHub workflow, named `singularity-build-deploy.yml` (the name doesn't really matter).
-* **Step 3**: In the top directory of your GitHub repository, create a file named `Singularity`.
-* **Step 4**: Copy-paste the content above and add to the Singularity file. (In principle it is possible to build this image locally, but we will not do that here, as we wish to build it with GitHub CI/CD).
-* **Step 5**: In the `singularity-build-deploy.yml` file, add the following content:
+* **Step 2**: In the empty repository, make a folder called `.github/workflows`. In this folder we will store the file containing the YAML script for a GitHub workflow, named `apptainer-build-deploy.yml` (the name doesn't really matter).
+* **Step 3**: In the top directory of your GitHub repository, create a file named `Apptainer`.
+* **Step 4**: Copy-paste the content above and add to the Apptainer file. (In principle it is possible to build this image locally, but we will not do that here, as we wish to build it with GitHub CI/CD).
+* **Step 5**: In the `apptainer-build-deploy.yml` file, add the following content:
 
 {% raw %}
 ```text
-name: Singularity Build Deploy
+name: Apptainer Build Deploy
 
 on:
   pull_request:
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build Container
         run: |
-           singularity build container.sif Singularity
+           singularity build container.sif Apptainer
 
       - name: Login and Deploy Container
         run: |
@@ -100,7 +100,7 @@ jobs:
 ```
 {% endraw %}
 
-The above script is designed to build and publish a Singularity image with [GitHub packages](https://github.com/features/packages).
+The above script is designed to build and publish a Apptainer image with [GitHub packages](https://github.com/features/packages).
 
 
 * **Step 6**: Add LICENSE and README as recommended in the [SW Carpentry Git-Novice Lesson](https://swcarpentry.github.io/git-novice/), and then the repository is good to go.

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 ---
 Apptainer (formerly known as Singularity) is a free and open-source container platform that allows you to create and run applications in isolated images (also called "containers") in a simple, portable, fast, and secure manner. It performs operating system level virtualization known as containerization. Many container platforms are available, but Apptainer is designed to bring containers and reproducibility to the scientific community and High-Performance Computing (HPC) use cases. Using Apptainer, developers can work in reproducible environments of their choice and design, and these complete environments can be easily copied and executed on other platforms.
 
-This is an introduction to Singularity/Apptainer, its motivations and applications in HEP.
+This is an introduction to Apptainer/Singularity, its motivations and applications in HEP.
 
 Based on the [Apptainer user guide](https://apptainer.org/docs/).
 

--- a/setup.md
+++ b/setup.md
@@ -2,29 +2,33 @@
 title: Setup
 ---
 
-<iframe width="427" height="251" src="https://www.youtube.com/embed/g0cCErlveiI?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Singularity/Apptainer #0 - Setup" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="427" height="251" src="https://www.youtube.com/embed/g0cCErlveiI?list=PLKZ9c4ONm-VkxWW98Gcn9H6WwykMiqtnF" title="Intro to Apptainer/Singularity #0 - Setup" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 In this document we use the names *Apptainer* and *Singularity* interchangeably. See the [Introduction]({{ page.root }}{% link _episodes/01-introduction.md %})
 for more details about existing Apptainer and Singularity versions and the differences between them.
 
-## Option 1: Use pre-installed singularity on a cluster
+## Option 1: Use pre-installed apptainer on a cluster
 
 Apptainer/Singularity has become popular and usually it is available in the institutional computing resources.
-Check if singularity is available with
+Check if apptainer or singularity are available with
 ```bash
+apptainer --version
 singularity --version
 ```
 If installed, you will see `apptainer version ...` or `singularity version ...`, depending on the flavor installed.
-If it is not in your [`$PATH`](https://www.makeuseof.com/set-path-variable-in-linux/#what-is-path-in-linux) you may still be able to use it via [CVMFS](https://cernvm.cern.ch/fs/): check if you have user namespaces enabled and CVMFS to run singularity that way:
+Apptainer is preferable but either one is OK, so if apptainer is there, no need to check for singularity (which most likely will be a link to apptainer).
+This tutorial requires at least Apptainer 1.0.x or Singularity 3.5.x. Previous versions may not have all the required features.
+If none is in your [`$PATH`](https://www.makeuseof.com/set-path-variable-in-linux/#what-is-path-in-linux) or if the available version is too old,
+you may still be able to use an updated apptainer via [CVMFS](https://cernvm.cern.ch/fs/): check if you have user namespaces enabled and CVMFS to run singularity that way:
 ```bash
 [[ $(cat /proc/sys/user/max_user_namespaces) -gt 0 ]] && ls /cvmfs/oasis.opensciencegrid.org/mis/ &>/dev/null && { export PATH=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/bin/:"$PATH"; echo "Success: Added to PATH"; singularity --version; } || echo "Failure: Unable to run Singularity/Apptainer via CVMFS"
 ```
-If this works, it will be added to your path and you will see your singularity/apptainer version.
+If this works, it will be added to your path and you will see your apptainer/singularity version.
 
 If your local computing system does not have Apptainer/Singularity installed, you may
 [request it to your system administrator as suggested here](https://apptainer.org/docs/user/main/quick_start.html#apptainer-on-a-shared-resource).
 
-## Option 2: Install singularity/Apptainer
+## Option 2: Install Apptainer/Singularity
 
 You will need a **Linux system (including WSL on Windows computers)** to run Apptainer/Singularity natively.
 **MacOS is not supported**.


### PR DESCRIPTION
Replaced singularity references w/ apptainer and set minimum version requirements

Min requirements are Apptainer >= 1.0.0 or Singularity >=3.5.0
Singularity is left as a secondary alternative and in the historic information

This PR fixes #108